### PR TITLE
Passing APIKey & APISecret to GetContestStandings

### DIFF
--- a/contest.go
+++ b/contest.go
@@ -177,20 +177,49 @@ func (c *Client) GetContestStandings(ctx context.Context, contestID int, options
 
 	// Check if APIKey and APISecret exist to make an authenticated request
 	if c.APIKey != "" && c.APISecret != "" {
+
 		v.Add("apiKey", c.APIKey)
 		v.Add("contestId", strconv.Itoa(contestID))
 		v.Add("time", strconv.FormatInt(time.Now().Unix(), 10))
-		apiSig := generateAPISig("contest.standings", c.APISecret, v)
-		v.Add("apiSig", apiSig)
-	} else {
-		if c.APIKey != "" || c.APISecret != "" {
-			c.Logger.Println("Missing APIKey or APISecret")
+
+		if options != nil {
+			if len(options.Handles) > 0 {
+				v.Add("handles", strings.Join(options.Handles, ";"))
+			}
+
+			if options.Count > 0 {
+				v.Add("count", string(options.Count))
+			}
+
+			if options.From > 0 {
+				v.Add("from", string(options.From))
+			}
+
+			if options.Room > 0 {
+				v.Add("room", string(options.Room))
+			}
+
+			if options.ShowUnofficial {
+				v.Add("showUnofficial", "true")
+			}
 		}
+
+		apiSig := generateAPISig("contest.standings", c.APISecret, v)
+
+		v.Add("apiSig", apiSig)
+
+		// All options is already inside the url at this point because apiSig need
+		// to hash the url having all the parameters. If options is added after the
+		// hash, CF can`t check hash properly
+		options = nil
+	} else {
 		v.Add("contestId", strconv.Itoa(contestID))
 	}
 
-	spath := "/contest.standings" + "?" + v.Encode()
+	spath := "/contest.standings" + "?" + v.Encode() + "&"
+
 	req, err := c.newRequest(ctx, "GET", spath, options.options(), nil)
+
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
After a while trying to figure out why I was not able to get the standings from a private contest when I was calling ```GetContestStandings``` method, I discovered that this method (and others) were not sending the APIKey and APISecret in the request URL, so I changed only this method (because I only tried in ```GetContestStandings```) to now be able to request the standings from a private group that I have in college. 

If you want to check out the project that I'm working on that use your package, just look [here](https://github.com/apc-unb/apc-api). I'm still developing the API and I just discovered how to get the standings from a private group. 

Given that, I pretend to fully use your package in my [project](https://github.com/apc-unb/apc-api).